### PR TITLE
Fix: Pass ISSUE_ASSIGN_TOKEN as action input

### DIFF
--- a/.github/workflows/self-assign-reusable.yml
+++ b/.github/workflows/self-assign-reusable.yml
@@ -65,9 +65,8 @@ jobs:
           ${{ github.event.issue != null
               && startsWith(github.event.comment.body, inputs.trigger) }}
         uses: bdougie/take-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.ISSUE_ASSIGN_TOKEN }}
         with:
+          token: ${{ secrets.ISSUE_ASSIGN_TOKEN }}
           message: ${{ inputs.message }}
           blockingLabels: ${{ inputs.blockingLabels }}
           blockingLabelsMessage: 'This issue is currently unavailable. Please choose another issue.'


### PR DESCRIPTION
## Summary

- Pass `ISSUE_ASSIGN_TOKEN` as the `token` input to `bdougie/take-action` instead of as a `GITHUB_TOKEN` env var

`bdougie/take-action` maps `inputs.token` to the internal `GITHUB_PAT` env var used in its curl calls. Setting `GITHUB_TOKEN` as an env var had no effect, leaving `GITHUB_PAT` empty and causing 401 "Bad credentials" on every assignment and comment API call.

The workflow reported success because the action uses bare `curl` without `-f`, so HTTP 401 responses don't fail the step.

Fixes kagenti/kagenti#1125