### PR TITLE
docs: Update org profile README with all repositories

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,23 +1,26 @@
 ## Kagenti - The Agentic Platform
-Kagenti is a Cloud-native middleware providing a framework-neutral, scalable and secure platform for deploying and orchestrating AI agents through a standardized REST API.
+An open source platform for building, deploying, securing, and governing AI agents on Kubernetes.
 
-This project consists of following repositories:
+Built on open standards:
+- [A2A](https://github.com/google/A2A) — agent-to-agent communication
+- [MCP](https://modelcontextprotocol.io/) — agent-to-tool integration
 
-1. **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and Documentation (Python)
-2. **[adk](https://github.com/kagenti/adk)** - Kagenti Agent Development Kit (Python)
-3. **[adk-starter](https://github.com/kagenti/adk-starter)** - Starter template for building agents with the Kagenti ADK (Python)
-4. **[agent-examples](https://github.com/kagenti/agent-examples)** - Sample agents and tools (Python)
-5. **[kagenti-operator](https://github.com/kagenti/kagenti-operator)** - Kubernetes operator for deploying and lifecycle management of agents and tools (Go)
-6. **[kagenti-extensions](https://github.com/kagenti/kagenti-extensions)** - Kubernetes security extensions for zero-trust agent authentication (Go)
-7. **[agentic-control-plane](https://github.com/kagenti/agentic-control-plane)** - Control plane composed of specialized A2A agents coordinated through Kagenti CRDs (Python)
-8. **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy-based MCP Gateway (Python)
-9. **[mcp-gateway](https://github.com/Kuadrant/mcp-gateway)** - Envoy-based MCP Gateway (Go) — *hosted under [Kuadrant](https://github.com/Kuadrant) org*
-10. **[onecli](https://github.com/kagenti/onecli)** - Open-source credential vault, give your AI agents access to services without exposing keys (TypeScript)
-11. **[humr](https://github.com/kagenti/humr)** - Run AI harnesses in production. Isolated. Credentialed. Scheduled. (TypeScript)
-12. **[ecosystem-guide](https://github.com/kagenti/ecosystem-guide)** - Central reference for the Kagenti ecosystem
-13. **[capture-the-flag](https://github.com/kagenti/capture-the-flag)** - Capture the flag scenarios to demonstrate and test Kagenti's security posture
-14. **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform (Python)
-15. **[.github](https://github.com/kagenti/.github)** - Project website and documentation (Hugo/HTML)
+### Repositories
+
+- **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and documentation (Python)
+- **[ecosystem-guide](https://github.com/kagenti/ecosystem-guide)** - Central reference for the Kagenti ecosystem
+- **[adk](https://github.com/kagenti/adk)** - Kagenti Agent Development Kit (Python)
+- **[adk-starter](https://github.com/kagenti/adk-starter)** - Starter template for building agents with the Kagenti ADK (Python)
+- **[agent-examples](https://github.com/kagenti/agent-examples)** - Sample agents and tools (Python)
+- **[kagenti-operator](https://github.com/kagenti/kagenti-operator)** - Kubernetes operator for deploying and lifecycle management of agents and tools (Go)
+- **[kagenti-extensions](https://github.com/kagenti/kagenti-extensions)** - Kubernetes security extensions for zero-trust agent authentication (Go)
+- **[agentic-control-plane](https://github.com/kagenti/agentic-control-plane)** - Control plane composed of specialized A2A agents coordinated through Kagenti CRDs (Python)
+- **[mcp-gateway](https://github.com/Kuadrant/mcp-gateway)** - Envoy-based MCP gateway (Go) — *hosted under [Kuadrant](https://github.com/Kuadrant) org*
+- **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy-based MCP gateways (Python)
+- **[onecli](https://github.com/kagenti/onecli)** - Open-source credential vault that gives your AI agents access to services without exposing keys (TypeScript)
+- **[capture-the-flag](https://github.com/kagenti/capture-the-flag)** - Capture the flag scenarios to demonstrate and test Kagenti's security posture
+- **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform (Python)
+- **[.github](https://github.com/kagenti/.github)** - Project website and documentation (Hugo/HTML)
 
 Want to contribute? Check our [CONTRIBUTING](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md) page.
 Project is maintained by [a team of developers](https://github.com/kagenti/kagenti/blob/main/MAINTAINERS.md).

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,15 +3,21 @@ Kagenti is a Cloud-native middleware providing a framework-neutral, scalable and
 
 This project consists of following repositories:
 
-1. **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and Documentation
-2. **[agent-examples](https://github.com/kagenti/agent-examples)** - Sample agents and tools (Python)
-3. **[mcp-gateway](https://github.com/kagenti/mcp-gateway)** - Envoy-based MCP Gateway (Go)
-4. **[kagenti-operator](https://github.com/kagenti/kagenti-operator)** - Kubernetes operator for agents/tools (Go)
-5. **[.github](https://github.com/kagenti/.github)** - Project website and documentation (Hugo/HTML)
-6. **[kagenti-extensions](https://github.com/kagenti/kagenti-extensions)** - Extensions and plugins (Go)
-7. **[agentic-control-plane](https://github.com/kagenti/agentic-control-plane)** - Control plane composed of specialized A2A agents coordinated through Kagenti CRDs.
-8. **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy gateways
-9. **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform
+1. **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and Documentation (Python)
+2. **[adk](https://github.com/kagenti/adk)** - Kagenti Agent Development Kit (Python)
+3. **[adk-starter](https://github.com/kagenti/adk-starter)** - Starter template for building agents with the Kagenti ADK (Python)
+4. **[agent-examples](https://github.com/kagenti/agent-examples)** - Sample agents and tools (Python)
+5. **[kagenti-operator](https://github.com/kagenti/kagenti-operator)** - Kubernetes operator for deploying and lifecycle management of agents and tools (Go)
+6. **[kagenti-extensions](https://github.com/kagenti/kagenti-extensions)** - Kubernetes security extensions for zero-trust agent authentication (Go)
+7. **[agentic-control-plane](https://github.com/kagenti/agentic-control-plane)** - Control plane composed of specialized A2A agents coordinated through Kagenti CRDs (Python)
+8. **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy-based MCP Gateway (Python)
+9. **[mcp-gateway](https://github.com/Kuadrant/mcp-gateway)** - Envoy-based MCP Gateway (Go) — *hosted under [Kuadrant](https://github.com/Kuadrant) org*
+10. **[onecli](https://github.com/kagenti/onecli)** - Open-source credential vault, give your AI agents access to services without exposing keys (TypeScript)
+11. **[humr](https://github.com/kagenti/humr)** - Run AI harnesses in production. Isolated. Credentialed. Scheduled. (TypeScript)
+12. **[ecosystem-guide](https://github.com/kagenti/ecosystem-guide)** - Central reference for the Kagenti ecosystem
+13. **[capture-the-flag](https://github.com/kagenti/capture-the-flag)** - Capture the flag scenarios to demonstrate and test Kagenti's security posture
+14. **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform (Python)
+15. **[.github](https://github.com/kagenti/.github)** - Project website and documentation (Hugo/HTML)
 
 Want to contribute? Check our [CONTRIBUTING](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md) page.
 Project is maintained by [a team of developers](https://github.com/kagenti/kagenti/blob/main/MAINTAINERS.md).

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,16 +7,16 @@ Built on open standards:
 
 ### Repositories
 
-- **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and documentation (Python)
 - **[ecosystem-guide](https://github.com/kagenti/ecosystem-guide)** - Central reference for the Kagenti ecosystem
+- **[kagenti](https://github.com/kagenti/kagenti)** - Main installer, UI, and documentation (Python)
 - **[adk](https://github.com/kagenti/adk)** - Kagenti Agent Development Kit (Python)
 - **[adk-starter](https://github.com/kagenti/adk-starter)** - Starter template for building agents with the Kagenti ADK (Python)
 - **[agent-examples](https://github.com/kagenti/agent-examples)** - Sample agents and tools (Python)
 - **[kagenti-operator](https://github.com/kagenti/kagenti-operator)** - Kubernetes operator for deploying and lifecycle management of agents and tools (Go)
 - **[kagenti-extensions](https://github.com/kagenti/kagenti-extensions)** - Kubernetes security extensions for zero-trust agent authentication (Go)
 - **[agentic-control-plane](https://github.com/kagenti/agentic-control-plane)** - Control plane composed of specialized A2A agents coordinated through Kagenti CRDs (Python)
-- **[mcp-gateway](https://github.com/Kuadrant/mcp-gateway)** - Envoy-based MCP gateway (Go) — *hosted under [Kuadrant](https://github.com/Kuadrant) org*
-- **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy-based MCP gateways (Python)
+- **[mcp-gateway](https://github.com/Kuadrant/mcp-gateway)** - Envoy-based MCP Gateway (Go) — *hosted under [Kuadrant](https://github.com/Kuadrant) org*
+- **[plugins-adapter](https://github.com/kagenti/plugins-adapter)** - Adapter for security and safety plugins for Envoy-based MCP Gateway (Python)
 - **[onecli](https://github.com/kagenti/onecli)** - Open-source credential vault that gives your AI agents access to services without exposing keys (TypeScript)
 - **[capture-the-flag](https://github.com/kagenti/capture-the-flag)** - Capture the flag scenarios to demonstrate and test Kagenti's security posture
 - **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform (Python)

--- a/profile/README.md
+++ b/profile/README.md
@@ -22,12 +22,12 @@ Built on open standards:
 - **[workload-harness](https://github.com/kagenti/workload-harness)** - Tools for agent load generation on the Kagenti platform (Python)
 - **[.github](https://github.com/kagenti/.github)** - Project website and documentation (Hugo/HTML)
 
-Want to contribute? Check our [CONTRIBUTING](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md) page.
-Project is maintained by [a team of developers](https://github.com/kagenti/kagenti/blob/main/MAINTAINERS.md).
+### Get involved
 
-Find out more: [http://kagenti.io](http://kagenti.io)
-
-Let's chat! Meet us on our [Kagenti Discord](https://discord.gg/aJ92dNDzqB) channel!
+- 📖 Start with the [CONTRIBUTING](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md) guide
+- 👥 Meet the [maintainers](https://github.com/kagenti/kagenti/blob/main/MAINTAINERS.md)
+- 🌐 Learn more at [kagenti.io](http://kagenti.io)
+- 💬 Or just come say hi in the [Kagenti Discord](https://discord.gg/aJ92dNDzqB)
 <!--
 
 **Here are some ideas to get you started:**


### PR DESCRIPTION
## Summary

- Update tagline to focus on Kubernetes and AI agents
- Add Built on open standards section referencing A2A and MCP
- Add 5 missing repositories: adk, adk-starter, onecli, ecosystem-guide, capture-the-flag
- Update mcp-gateway link to point to the Kuadrant org where it now lives
- Switch from numbered list to bullets so the list does not feel ranked
- Reorder repos for discovery: kagenti first (main repo), then ecosystem-guide, then ADK/examples, then infrastructure and tooling
- Improve descriptions and standardize punctuation

Addresses feedback from @jenna-winkler, @rubambiza, @mrsabath, and Copilot.

## Test plan

- [ ] Verify the org profile page (https://github.com/kagenti) renders correctly after merge
- [ ] Confirm all repository links resolve to valid repos