### PR TITLE
CI: Pin action-pr-title to SHA (v1.0.2)

### DIFF
--- a/.github/workflows/pr-verifier-required.yml
+++ b/.github/workflows/pr-verifier-required.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Enforce PR title prefixes (case-sensitive)
-        uses: deepakputhraya/action-pr-title@v2
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
         with:
           # Union of conventional and template-derived categories
           allowed_prefixes: >


### PR DESCRIPTION
## Summary
- Pins `deepakputhraya/action-pr-title` to commit SHA `3864bebc` (v1.0.2)
- The previous `@v2` ref does not exist (only v1.0.x tags are published), causing all PR title checks to fail
- Uses SHA pinning per org convention