### PR TITLE
CI: Force Node.js 24 for action-pr-title

### DIFF
--- a/.github/workflows/pr-verifier-required.yml
+++ b/.github/workflows/pr-verifier-required.yml
@@ -10,6 +10,9 @@ jobs:
     if: ${{ github.repository != 'kagenti/.github' }}
     runs-on: ubuntu-latest
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     permissions:
       pull-requests: read
 


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to the PR verifier job
- Suppresses the Node.js 20 deprecation warning on all caller repos
- The action only uses `@actions/core` and `@actions/github` (string matching + one REST call), verified safe for Node 24