### PR TITLE
feat: add optional version field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report.yml
@@ -35,6 +35,17 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: version
+    attributes:
+      label: Kagenti Version
+      description: |
+        If this bug is for the Kagenti platform, which version were you running? Check with:
+        helm list -n kagenti-system (app version column), or the git tag you checked out.
+      placeholder: "v0.6.0"
+    validations:
+      required: false
+
   - type: textarea
     id: additional
     attributes:

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+TEMP_FILE=$(mktemp)
+
+# Check if any AI co-author trailers exist before stripping
+HAS_AI_TRAILER=false
+if grep -qi -E '^Co-authored-by:.*(Claude|Cursor|anthropic)' "$COMMIT_MSG_FILE"; then
+  HAS_AI_TRAILER=true
+fi
+
+# Strip Co-authored-by lines for Claude/Cursor and Made-with lines
+grep -vi -E '^Co-authored-by:.*(Claude|Cursor|anthropic|cursor)' "$COMMIT_MSG_FILE" \
+  | grep -vi '^Made-with:' \
+  > "$TEMP_FILE" || true
+
+# Remove trailing blank lines (awk is portable across macOS/Linux unlike sed labels)
+awk '/^[[:space:]]*$/{buf=buf $0 ORS; next} {if(buf) printf "%s",buf; buf=""; print}' "$TEMP_FILE" > "$COMMIT_MSG_FILE"
+
+# If AI trailers were present, add Assisted-By instead
+if [ "$HAS_AI_TRAILER" = true ]; then
+  # Ensure there's a blank line before the trailer
+  echo "" >> "$COMMIT_MSG_FILE"
+  echo "Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>" >> "$COMMIT_MSG_FILE"
+fi
+
+rm -f "$TEMP_FILE"


### PR DESCRIPTION
## Summary

- Adds an optional "Kagenti Version" input field to the bug report template
- Adds `scripts/hooks/commit-msg` hook (propagated from kagenti/kagenti) to enforce `Assisted-By` attribution policy

Closes #74

## Test plan

- [ ] Open a new bug report on any kagenti org repo and verify the version field appears between "Expected Behavior" and "Additional Context"
- [ ] Verify the field is optional (form submits without it)

Assisted-By: Claude Code