### PR TITLE
Docs: Add meeting calendar and remove deprecated contact methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,9 +389,12 @@ kubectl logs -f deployment/slack-researcher -n &lt;namespace&gt;</code></pre>
         <div class="community-cols">
 
           <div class="community-col">
+            <h3 class="community-col-label">Community meetings</h3>
+            <p>We meet on Wednesdays. See the <a href="https://calendar.google.com/calendar/embed?src=kagenti%40kagenti.io&amp;ctz=America%2FNew_York" rel="noopener noreferrer">Kagenti community calendar</a> for the schedule — calendar invites include a Google Meet link.</p>
+            <iframe src="https://calendar.google.com/calendar/embed?src=kagenti%40kagenti.io&amp;ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
             <h3 class="community-col-label">Become a contributor</h3>
             <p>We're building in public and want to hear from platform engineers, security teams, and AI infrastructure builders.</p>
-            <p>Start a thread on <a href="https://github.com/kagenti/kagenti/discussions" rel="noopener noreferrer">GitHub Discussions</a>, find us on <a href="https://kagenti.slack.com/join/shared_invite/zt-3uqttqbgm-HlrQ6gezs0E8AFYOCZ~wVw#/shared-invite/email" rel="noopener noreferrer">Slack</a>, <a href="https://groups.google.com/g/kagenti-contributors/" rel="noopener noreferrer">join the mailing list</a>, or <a href="mailto:kagenti-maintainers@googlegroups.com">email the core team</a>.</p>
+            <p>Find us on <a href="https://kagenti.slack.com/join/shared_invite/zt-3uqttqbgm-HlrQ6gezs0E8AFYOCZ~wVw#/shared-invite/email" rel="noopener noreferrer">Slack</a>, <a href="https://groups.google.com/g/kagenti-contributors/" rel="noopener noreferrer">join the mailing list</a>, or <a href="mailto:kagenti-maintainers@googlegroups.com">email the core team</a>.</p>
             <h3 class="community-col-label">Contributors</h3>
             <div class="contributor-avatars">
             <a href="https://github.com/pdettori" rel="noopener noreferrer"><img src="https://avatars.githubusercontent.com/u/6678093?v=4&s=48" alt="pdettori" width="36" height="36" loading="lazy"></a>
@@ -421,7 +424,6 @@ kubectl logs -f deployment/slack-researcher -n &lt;namespace&gt;</code></pre>
             <h3 class="community-col-label">What's next</h3>
             <p>The next phase of Kagenti is built around persistent, long-running agents — agents that maintain context across sessions and operate autonomously over time, like <a href="https://github.com/openclaw/openclaw" rel="noopener noreferrer">OpenClaw</a>.</p>
             <p>Getting there means building the right foundations. We're working on the core pieces: memory, sandboxing, an Agent Development Kit, and improved developer experience.</p>
-            <p><a href="https://github.com/kagenti/kagenti/discussions" rel="noopener noreferrer">Become a contributor →</a></p>
           </div>
 
         </div><!-- /.community-cols -->


### PR DESCRIPTION
## Summary

Adds the Community Meeting calendar to the web site.
Removes deprecated contact methods (GitHub discussions)

## (Optional) Testing Instructions

Bring this PR into your workspace and open index.html in a browser.

Fixes #

Resolves #73
