### PR TITLE
Docs: Use correct link to join Kagenti Slack

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@ kubectl logs -f deployment/slack-researcher -n &lt;namespace&gt;</code></pre>
             <iframe src="https://calendar.google.com/calendar/embed?src=kagenti%40kagenti.io&amp;ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
             <h3 class="community-col-label">Become a contributor</h3>
             <p>We're building in public and want to hear from platform engineers, security teams, and AI infrastructure builders.</p>
-            <p>Find us on <a href="https://kagenti.slack.com/join/shared_invite/zt-3uqttqbgm-HlrQ6gezs0E8AFYOCZ~wVw#/shared-invite/email" rel="noopener noreferrer">Slack</a>, <a href="https://groups.google.com/g/kagenti-contributors/" rel="noopener noreferrer">join the mailing list</a>, or <a href="mailto:kagenti-maintainers@googlegroups.com">email the core team</a>.</p>
+            <p>Find us on <a href="https://ibm.biz/kagenti-slack" rel="noopener noreferrer">Slack</a>, <a href="https://groups.google.com/g/kagenti-contributors/" rel="noopener noreferrer">join the mailing list</a>, or <a href="mailto:kagenti-maintainers@googlegroups.com">email the core team</a>.</p>
             <h3 class="community-col-label">Contributors</h3>
             <div class="contributor-avatars">
             <a href="https://github.com/pdettori" rel="noopener noreferrer"><img src="https://avatars.githubusercontent.com/u/6678093?v=4&s=48" alt="pdettori" width="36" height="36" loading="lazy"></a>
@@ -587,7 +587,7 @@ kubectl logs -f deployment/slack-researcher -n &lt;namespace&gt;</code></pre>
           <h4>Community</h4>
           <ul>
             <li><a href="https://github.com/kagenti/kagenti" rel="noopener noreferrer">GitHub</a></li>
-            <li><a href="https://kagenti.slack.com/join/shared_invite/zt-3uqttqbgm-HlrQ6gezs0E8AFYOCZ~wVw#/shared-invite/email" rel="noopener noreferrer">Slack</a></li>
+            <li><a href="https://ibm.biz/kagenti-slack" rel="noopener noreferrer">Slack</a></li>
             <li><a href="https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md" rel="noopener noreferrer">Contributing</a></li>
             <li><a href="https://github.com/orgs/kagenti/projects/8" rel="noopener noreferrer">Roadmap</a></li>
           </ul>


### PR DESCRIPTION
## Summary

The current links to join Kagenti Slack point to an old invitation that required an @kagenti.io email address and didn't use our official page.

Fixes #

Resolves https://github.com/kagenti/kagenti/issues/1853