### PR TITLE
fix: add missing skip_file.txt and pin actions/checkout to v6.0.3

### DIFF
--- a/.github/workflows/link_checker.yaml
+++ b/.github/workflows/link_checker.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check links with linkcheck
         uses: filiph/linkcheck@3.0.0
         with:

--- a/skip_file.txt
+++ b/skip_file.txt
@@ -1,0 +1,2 @@
+# URLs matching these patterns will be skipped by the link checker.
+# Each line is a regular expression.


### PR DESCRIPTION
## Summary

- Adds empty `skip_file.txt` that the link checker workflow references but was missing
- Pins `actions/checkout` to v6.0.3 SHA for Node.js 24 support (Node.js 20 deprecated June 16, 2026)

Closes #81

## Test plan

- [ ] Workflow runs successfully after merge (no more `PathNotFoundException`)
- [ ] No Node.js 20 deprecation warning in workflow logs

Assisted-By: Claude Code