### PR TITLE
Add Kagenti → Rosso rebrand announcement banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,17 @@
 
   <a class="skip-link" href="#main-content">Skip to main content</a>
 
-  <div class="banner" id="event-banner">
+  <div class="banner banner-rebrand" id="rebrand-banner">
+    <div class="container">
+      <p>
+        <span class="rebrand-pill">New name</span>
+        <strong>Kagenti is becoming Rosso</strong><span class="banner-detail"> — you'll see the new name reflected across all project sites soon.</span>
+      </p>
+      <button class="banner-close" aria-label="Dismiss rebrand announcement" onclick="dismissRebrandBanner()">×</button>
+    </div>
+  </div>
+
+  <div class="banner hidden" id="event-banner">
     <div class="container">
       <p>
         <strong>Find Kagenti at KubeCon NA</strong><span class="banner-detail"> — Nov 9–12.</span>

--- a/script.js
+++ b/script.js
@@ -17,11 +17,22 @@ function dismissBanner() {
   try { sessionStorage.setItem('kagenti-banner-dismissed', '1'); } catch (e) {}
 }
 
+function dismissRebrandBanner() {
+  var banner = document.getElementById('rebrand-banner');
+  if (!banner) return;
+  banner.classList.add('hidden');
+  try { sessionStorage.setItem('kagenti-rebrand-dismissed', '1'); } catch (e) {}
+}
+
 (function () {
   try {
     if (sessionStorage.getItem('kagenti-banner-dismissed') === '1') {
       var banner = document.getElementById('event-banner');
       if (banner) banner.classList.add('hidden');
+    }
+    if (sessionStorage.getItem('kagenti-rebrand-dismissed') === '1') {
+      var rebrand = document.getElementById('rebrand-banner');
+      if (rebrand) rebrand.classList.add('hidden');
     }
   } catch (e) {}
 })();

--- a/style.css
+++ b/style.css
@@ -169,6 +169,29 @@ body {
 .banner-close:hover { opacity: 1; }
 .banner.hidden { display: none; }
 
+/* Rebrand announcement banner (Kagenti → Rosso) */
+.banner-rebrand {
+  background: #fdecec;            /* light red tint — distinct from the dark event banner */
+  color: var(--c-text);
+  border-bottom: 2px solid #ee0000;
+}
+.banner-rebrand .banner-close { color: var(--c-text); }
+.banner-rebrand a { color: #cc0000; border-bottom-color: rgba(204,0,0,0.4); }
+.banner-rebrand a:hover { border-bottom-color: #cc0000; }
+.rebrand-pill {
+  display: inline-block;
+  background: #cc0000;
+  color: #f9f9f7;
+  font-weight: 700;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  margin-right: var(--sp-3);
+  vertical-align: middle;
+}
+
 /* --------------------------------------------------------------------------
    Header
    -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Adds a dismissible announcement banner at the top of the landing page noting the upcoming **Kagenti → Rosso** rename:

> **NEW NAME** — Kagenti is becoming Rosso — you'll see the new name reflected across all project sites soon.

It's styled as a light red-tinted bar with a brand-red accent and a `NEW NAME` pill, so it reads as a distinct announcement rather than blending into the existing dark event banner. The KubeCon event banner is hidden (markup kept, just `hidden` class added) so the rebrand message stands alone.

## Changes
- **index.html** — new `#rebrand-banner`; hide the KubeCon `#event-banner`
- **style.css** — `.banner-rebrand` + `.rebrand-pill` styles (AA-compliant contrast)
- **script.js** — independent dismiss handler with session-storage persistence, mirroring the existing event-banner pattern

## Notes
- Reuses the existing `.banner` system — no new patterns introduced.
- The event banner is only hidden, not deleted, so it's trivial to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)