### PR TITLE
fix: Skip Google Fonts preconnect URLs in link checker

### DIFF
--- a/skip_file.txt
+++ b/skip_file.txt
@@ -1,2 +1,6 @@
 # URLs matching these patterns will be skipped by the link checker.
 # Each line is a regular expression.
+
+# Google Fonts preconnect hints — bare domains return 404 when fetched directly
+fonts\.googleapis\.com
+fonts\.gstatic\.com


### PR DESCRIPTION
## Summary

- Add `fonts\.googleapis\.com` and `fonts\.gstatic\.com` patterns to `skip_file.txt`
- These are `<link rel="preconnect">` hints (bare domains) that return HTTP 404 when fetched directly by the link checker

Failing run: https://github.com/kagenti/.github/actions/runs/27223486800/job/80384287056

Fixes #84

Assisted-By: Claude Code